### PR TITLE
Minor fixes, integrate with Iris out-of-the-box

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,25 @@ version: '3'
 services:
   oncall-web:
     build: .
+    hostname: oncall
     ports:
       - "8080:8080"
     environment:
       - DOCKER_DB_BOOTSTRAP=1
+      - IRIS_API_HOST=iris
     volumes:
       - ./configs/config.docker.yaml:/home/oncall/config/config.yaml
-
+    networks:
+      - iris
+  
   oncall-mysql:
+    hostname: oncall-mysql
     image: mysql:5.7
     environment:
       - MYSQL_ROOT_PASSWORD=1234
+    networks:
+      - iris
+
+networks:
+  iris:
+    name: iris

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
         'asn1crypto==1.0.0',
         'gevent==1.4.0',
         'ujson',
+        'markupsafe',
         'sqlalchemy',
         'PyYAML',
         'PyMYSQL',

--- a/src/oncall/app.py
+++ b/src/oncall/app.py
@@ -4,6 +4,7 @@ from urllib.parse import unquote_plus
 from importlib import import_module
 
 import falcon
+import os
 import re
 from beaker.middleware import SessionMiddleware
 from falcon_cors import CORS
@@ -130,7 +131,7 @@ def init(config):
              "default-src 'self' %s 'unsafe-eval' ; "
              "font-src 'self' data: blob; img-src data: uri https: http:; "
              "style-src 'unsafe-inline' https: http:;" %
-             config.get('iris_plan_integration', {}).get('api_host', '')))
+             os.environ.get("IRIS_API_HOST", config.get('iris_plan_integration', {}).get('api_host', ''))))
         logging.basicConfig(level=logging.INFO)
         logger.info('%s', security_headers)
     else:

--- a/src/oncall/bin/notifier.py
+++ b/src/oncall/bin/notifier.py
@@ -132,7 +132,7 @@ def metrics_sender():
 
 
 def main():
-    with open(sys.argv[1], 'r') as config_file:
+    with open(sys.argv[1], 'r', encoding='utf-8') as config_file:
         config = yaml.safe_load(config_file)
 
     init_notifier(config)

--- a/src/oncall/utils.py
+++ b/src/oncall/utils.py
@@ -77,7 +77,7 @@ def subscribe_notifications(team, user, cursor):
                                                                       `type_id`, `time_before`)
                                   VALUES ((SELECT id FROM user WHERE name = %s),
                                           (SELECT id FROM team WHERE name = %s),
-                                          (SELECT id FROM contact_mode WHERE name = %s),
+                                          (SELECT id FROM contact_mode WHERE name = %s LIMIT 1),
                                           (SELECT id FROM notification_type WHERE name = %s),
                                            %s);''',
                                (user, team, mode, ONCALL_REMINDER, time))


### PR DESCRIPTION
Changes:
- fixes issues where multiple rows are returned (defensive against bad data in db)
- makes docker-compose work with iris docker-compose and oncall-admin
  (same network, hostnames)
- minor fixes, logging to stdout in docker

Few things still todo